### PR TITLE
feat(core): add Typst (.typ) file extraction

### DIFF
--- a/config/colophon.toml.example
+++ b/config/colophon.toml.example
@@ -40,8 +40,10 @@ log_level = "info"
 dir = "."
 
 # File extensions to include (without the leading dot).
+# Supported: md (Markdown), typ (Typst)
 # Default: ["md"]
 extensions = ["md"]
+# extensions = ["md", "typ"]
 
 # File names to exclude from processing (exact filename match).
 # Default: []

--- a/config/colophon.yaml.example
+++ b/config/colophon.yaml.example
@@ -39,9 +39,11 @@ source:
   dir: "."
 
   # File extensions to include (without the leading dot).
+  # Supported: md (Markdown), typ (Typst)
   # Default: [md]
   extensions:
     - md
+    # - typ
 
   # File names to exclude from processing (exact filename match).
   # Default: []

--- a/crates/colophon-core/src/curate/claude.rs
+++ b/crates/colophon-core/src/curate/claude.rs
@@ -564,8 +564,10 @@ mod tests {
 
     #[test]
     fn system_prompt_full_mode() {
-        let mut config = CurateConfig::default();
-        config.full_candidates = true;
+        let config = CurateConfig {
+            full_candidates: true,
+            ..CurateConfig::default()
+        };
         let prompt = build_system_prompt(&config);
         assert!(prompt.contains("indexer"));
         assert!(prompt.contains("YAML with fields per candidate"));
@@ -573,8 +575,10 @@ mod tests {
 
     #[test]
     fn system_prompt_custom_replaces_default() {
-        let mut config = CurateConfig::default();
-        config.system_prompt = Some("Custom prompt.".to_string());
+        let config = CurateConfig {
+            system_prompt: Some("Custom prompt.".to_string()),
+            ..CurateConfig::default()
+        };
         let prompt = build_system_prompt(&config);
         assert!(prompt.starts_with("Custom prompt."));
         assert!(!prompt.contains("indexer"));
@@ -605,8 +609,10 @@ mod tests {
 
     #[test]
     fn stdin_payload_full() {
-        let mut config = CurateConfig::default();
-        config.full_candidates = true;
+        let config = CurateConfig {
+            full_candidates: true,
+            ..CurateConfig::default()
+        };
         let candidates = CandidatesFile {
             version: 1,
             generated: "2026-03-10T12:00:00Z".to_string(),
@@ -621,8 +627,10 @@ mod tests {
 
     #[test]
     fn stdin_payload_with_user_prompt() {
-        let mut config = CurateConfig::default();
-        config.prompt = Some("Focus on security terms.".to_string());
+        let config = CurateConfig {
+            prompt: Some("Focus on security terms.".to_string()),
+            ..CurateConfig::default()
+        };
         let candidates = CandidatesFile {
             version: 1,
             generated: "2026-03-10T12:00:00Z".to_string(),

--- a/crates/colophon-core/src/extract/mod.rs
+++ b/crates/colophon-core/src/extract/mod.rs
@@ -3,6 +3,7 @@
 pub mod candidates;
 pub mod keywords;
 pub mod markdown;
+pub mod typst;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -15,7 +16,7 @@ use crate::error::{ExtractError, ExtractResult};
 
 use self::candidates::{Candidate, CandidateLocation, CandidatesFile};
 use self::keywords::{extract_tfidf, extract_yake, get_stop_words, trim_stopwords};
-use self::markdown::{extract_context, extract_prose};
+use self::markdown::extract_context;
 
 /// A parsed document ready for keyword extraction.
 struct Document {
@@ -52,16 +53,16 @@ pub fn run_with_progress(
         "collected source files"
     );
 
-    // 2. Parse markdown into prose, skip empties.
+    // 2. Parse into prose (dispatch by file extension), skip empties.
     let documents: Vec<Document> = raw_docs
         .into_iter()
-        .filter_map(|(path, content)| {
-            let prose = extract_prose(&content);
+        .filter_map(|(path, ext, content)| {
+            let prose = extract_prose_for(&content, &ext);
             if prose.is_empty() {
-                tracing::debug!(file = %path, "skipped file — no prose after markdown parse");
+                tracing::debug!(file = %path, ext, "skipped file — no prose after parse");
                 None
             } else {
-                tracing::debug!(file = %path, prose_len = prose.len(), "parsed prose");
+                tracing::debug!(file = %path, ext, prose_len = prose.len(), "parsed prose");
                 Some(Document {
                     relative_path: path,
                     prose,
@@ -407,14 +408,14 @@ pub fn run_with_progress(
 
 /// Walk `dir`, filter by extension and exclude list, read contents.
 ///
-/// Returns `(relative_path, content)` pairs sorted by path.
+/// Returns `(relative_path, extension, content)` tuples sorted by path.
 fn collect_documents(
     dir: &str,
     extensions: &[String],
     exclude: &[String],
-) -> ExtractResult<Vec<(String, String)>> {
+) -> ExtractResult<Vec<(String, String, String)>> {
     let base = Path::new(dir);
-    let mut docs: Vec<(String, String)> = Vec::new();
+    let mut docs: Vec<(String, String, String)> = Vec::new();
 
     for entry in WalkDir::new(dir).sort_by_file_name().into_iter() {
         let entry = entry.map_err(ExtractError::WalkDir)?;
@@ -425,13 +426,10 @@ fn collect_documents(
         let path = entry.path();
 
         // Check extension.
-        let ext_match = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| extensions.iter().any(|allowed| allowed == ext));
-        if !ext_match {
-            continue;
-        }
+        let ext = match path.extension().and_then(|e| e.to_str()) {
+            Some(ext) if extensions.iter().any(|allowed| allowed == ext) => ext.to_string(),
+            _ => continue,
+        };
 
         // Check exclude list (file name only).
         let file_name = path
@@ -454,10 +452,18 @@ fn collect_documents(
             source,
         })?;
 
-        docs.push((rel, content));
+        docs.push((rel, ext, content));
     }
 
     Ok(docs)
+}
+
+/// Extract prose from content based on file extension.
+fn extract_prose_for(content: &str, ext: &str) -> String {
+    match ext {
+        "typ" => typst::extract_prose(content),
+        _ => markdown::extract_prose(content),
+    }
 }
 
 /// Format a [`SystemTime`] as an RFC 3339-ish UTC timestamp without pulling in
@@ -1207,5 +1213,105 @@ mod tests {
             !has_oauth,
             "consolidated term exceeding max_doc_pct should be dropped"
         );
+    }
+
+    // ── Typst extraction ─────────────────────────────────────────
+
+    #[test]
+    fn pipeline_extracts_from_typst() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("auth.typ"),
+            "= Authentication\n\n\
+             OAuth provides delegated authorization. OAuth 2.0 is the \
+             current standard for token-based access control.\n\n\
+             == Passwords\n\nPassword hashing uses *bcrypt* or _argon2_.\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("api.typ"),
+            "= API Design\n\n\
+             RESTful APIs use HTTP methods for CRUD operations. \
+             Rate limiting protects against abuse.\n",
+        )
+        .unwrap();
+
+        let source = SourceConfig {
+            dir: tmp.path().to_string_lossy().to_string(),
+            extensions: vec!["typ".to_string()],
+            exclude: Vec::new(),
+        };
+        let result = run(&source, &ExtractConfig::default());
+        assert!(result.is_ok(), "typst pipeline should succeed: {result:?}");
+
+        let file = result.unwrap();
+        assert_eq!(file.document_count, 2);
+        assert!(!file.candidates.is_empty());
+    }
+
+    #[test]
+    fn pipeline_mixed_md_and_typst() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("intro.md"),
+            "# Introduction\n\nOAuth provides delegated authorization.\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("details.typ"),
+            "= Details\n\nTransport Layer Security encrypts data in transit.\n",
+        )
+        .unwrap();
+
+        let source = SourceConfig {
+            dir: tmp.path().to_string_lossy().to_string(),
+            extensions: vec!["md".to_string(), "typ".to_string()],
+            exclude: Vec::new(),
+        };
+        let result = run(&source, &ExtractConfig::default());
+        assert!(result.is_ok(), "mixed pipeline should succeed: {result:?}");
+
+        let file = result.unwrap();
+        assert_eq!(file.document_count, 2);
+        assert!(!file.candidates.is_empty());
+    }
+
+    #[test]
+    fn pipeline_typst_skips_code_and_math() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("ch1.typ"),
+            "= Chapter 1\n\n\
+             OAuth provides delegated authorization.\n\n\
+             The formula $x^2 + y^2 = z^2$ is Pythagoras.\n\n\
+             ```rust\nfn main() {}\n```\n\n\
+             TLS encrypts data in transit.\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("ch2.typ"),
+            "= Chapter 2\n\n\
+             Rate limiting protects against abuse.\n",
+        )
+        .unwrap();
+
+        let source = SourceConfig {
+            dir: tmp.path().to_string_lossy().to_string(),
+            extensions: vec!["typ".to_string()],
+            exclude: Vec::new(),
+        };
+        let file = run(&source, &ExtractConfig::default()).unwrap();
+
+        // Code and math should not appear in candidates.
+        for c in &file.candidates {
+            assert!(
+                !c.term.contains("fn main"),
+                "code should not appear in candidates"
+            );
+            assert!(
+                !c.term.contains("x^2"),
+                "math should not appear in candidates"
+            );
+        }
     }
 }

--- a/crates/colophon-core/src/extract/typst.rs
+++ b/crates/colophon-core/src/extract/typst.rs
@@ -1,0 +1,304 @@
+//! Typst parsing and prose text extraction.
+//!
+//! Walks the `typst-syntax` AST to extract prose text, skipping
+//! headings, code blocks, raw blocks, math equations, labels,
+//! and function calls — same strategy as the markdown extractor.
+
+use typst_syntax::{parse, SyntaxKind, SyntaxNode};
+
+/// Extract prose text from a Typst document.
+///
+/// Walks the syntax tree and collects `Text` nodes while skipping:
+/// - Headings (noisy short phrases, same rationale as markdown)
+/// - Raw/code blocks (`` `code` `` and `` ```lang ... ``` ``)
+/// - Math equations (`$...$`)
+/// - Labels (`<label>`) and references (`@ref`)
+/// - Code-mode expressions after `#` (function calls, imports, etc.)
+///
+/// Strong (`*bold*`) and emphasis (`_italic_`) text is preserved —
+/// the prose inside is meaningful for keyword extraction.
+pub fn extract_prose(source: &str) -> String {
+    let root = parse(source);
+    let mut prose = String::with_capacity(source.len() / 2);
+    walk_node(&root, &mut prose, false);
+    prose.trim().to_string()
+}
+
+/// Recursively walk a syntax node, appending prose text.
+fn walk_node(node: &SyntaxNode, out: &mut String, in_heading: bool) {
+    // Skip entirely — these contain no extractable prose.
+    if matches!(
+        node.kind(),
+        SyntaxKind::Raw
+            | SyntaxKind::Equation
+            | SyntaxKind::Label
+            | SyntaxKind::Ref
+            | SyntaxKind::RefMarker
+            | SyntaxKind::Link
+            | SyntaxKind::LineComment
+            | SyntaxKind::BlockComment
+            | SyntaxKind::Hash // Code-mode entry — skip function calls, imports, set/show rules.
+    ) {
+        return;
+    }
+
+    // Heading — set flag so child Text nodes are skipped.
+    if node.kind() == SyntaxKind::Heading {
+        for child in node.children() {
+            walk_node(child, out, true);
+        }
+        return;
+    }
+
+    match node.kind() {
+        // Text leaf — the prose we want (unless inside a heading).
+        SyntaxKind::Text if !in_heading => {
+            let text = node.text();
+            if !text.is_empty() {
+                if !out.is_empty() && !out.ends_with('\n') && !out.ends_with(' ') {
+                    out.push(' ');
+                }
+                out.push_str(text);
+            }
+        }
+
+        // Smart quotes — treat as punctuation prose.
+        SyntaxKind::SmartQuote if !in_heading => {
+            out.push('"');
+        }
+
+        // Paragraph/line breaks.
+        SyntaxKind::Parbreak | SyntaxKind::Linebreak => {
+            out.push('\n');
+        }
+
+        // Space — preserve word boundaries.
+        SyntaxKind::Space => {
+            if !out.is_empty() && !out.ends_with('\n') && !out.ends_with(' ') {
+                out.push(' ');
+            }
+        }
+
+        // Escape sequences — try to decode the visible character.
+        SyntaxKind::Escape if !in_heading => {
+            let text = node.text();
+            // Typst escapes: \#, \*, \_, etc. — just emit the char after \.
+            if text.starts_with('\\') && text.len() > 1 {
+                out.push_str(&text[1..]);
+            }
+        }
+
+        // Everything else — recurse into children.
+        _ => {
+            for child in node.children() {
+                walk_node(child, out, in_heading);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text() {
+        let result = extract_prose("Hello world. This is a test.");
+        assert_eq!(result, "Hello world. This is a test.");
+    }
+
+    #[test]
+    fn headings_excluded() {
+        let typ = "= Main Title\n\n== Subtitle\n\nBody text here.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("Main Title"));
+        assert!(!result.contains("Subtitle"));
+        assert!(result.contains("Body text here."));
+    }
+
+    #[test]
+    fn raw_inline_stripped() {
+        let typ = "Use the `println!` macro for output.";
+        let result = extract_prose(typ);
+        assert!(result.contains("Use the"));
+        assert!(result.contains("macro for output."));
+        assert!(!result.contains("println!"));
+    }
+
+    #[test]
+    fn raw_block_stripped() {
+        let typ = "Before code.\n\n```rust\nfn main() {}\n```\n\nAfter code.";
+        let result = extract_prose(typ);
+        assert!(result.contains("Before code."));
+        assert!(result.contains("After code."));
+        assert!(!result.contains("fn main()"));
+    }
+
+    #[test]
+    fn math_stripped() {
+        let typ = "The formula $x^2 + y^2 = z^2$ is well known.";
+        let result = extract_prose(typ);
+        assert!(result.contains("The formula"));
+        assert!(result.contains("is well known."));
+        assert!(!result.contains("x^2"));
+    }
+
+    #[test]
+    fn display_math_stripped() {
+        let typ = "Consider:\n\n$ sum_(i=0)^n i = n(n+1)/2 $\n\nThis is a sum.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("sum_"));
+        assert!(result.contains("This is a sum."));
+    }
+
+    #[test]
+    fn bold_and_italic_preserved() {
+        let typ = "This is *bold text* and _italic text_ in a sentence.";
+        let result = extract_prose(typ);
+        assert!(result.contains("bold text"));
+        assert!(result.contains("italic text"));
+    }
+
+    #[test]
+    fn list_items_preserved() {
+        let typ = "Shopping list:\n\n- Apples\n- Bananas\n- Cherries\n";
+        let result = extract_prose(typ);
+        assert!(result.contains("Apples"));
+        assert!(result.contains("Bananas"));
+        assert!(result.contains("Cherries"));
+    }
+
+    #[test]
+    fn enum_items_preserved() {
+        let typ = "Steps:\n\n+ First step\n+ Second step\n+ Third step\n";
+        let result = extract_prose(typ);
+        assert!(result.contains("First step"));
+        assert!(result.contains("Second step"));
+    }
+
+    #[test]
+    fn term_list_preserved() {
+        let typ = "/ OAuth: An authorization protocol.\n/ TLS: Transport layer security.\n";
+        let result = extract_prose(typ);
+        assert!(result.contains("OAuth"));
+        assert!(result.contains("authorization protocol"));
+        assert!(result.contains("TLS"));
+    }
+
+    #[test]
+    fn labels_stripped() {
+        let typ = "= Introduction <intro>\n\nSome text about the topic.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("<intro>"));
+        assert!(!result.contains("intro"));
+        assert!(result.contains("Some text about the topic."));
+    }
+
+    #[test]
+    fn references_stripped() {
+        let typ = "As discussed in @intro, the approach works.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("@intro"));
+        assert!(result.contains("the approach works."));
+    }
+
+    #[test]
+    fn links_stripped() {
+        let typ = "Visit https://example.com for details.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("https://"));
+        assert!(result.contains("Visit"));
+        assert!(result.contains("for details."));
+    }
+
+    #[test]
+    fn function_calls_stripped() {
+        let typ = "#set text(size: 12pt)\n\nActual content here.\n\n#pagebreak()";
+        let result = extract_prose(typ);
+        assert!(!result.contains("set text"));
+        assert!(!result.contains("pagebreak"));
+        assert!(result.contains("Actual content here."));
+    }
+
+    #[test]
+    fn content_blocks_in_functions_preserved() {
+        let typ = "#block[This prose should be extracted.]\n\nMore text.";
+        let result = extract_prose(typ);
+        assert!(result.contains("This prose should be extracted."));
+        assert!(result.contains("More text."));
+    }
+
+    #[test]
+    fn comments_stripped() {
+        let typ = "// This is a comment\nVisible text.\n/* block comment */\nMore text.";
+        let result = extract_prose(typ);
+        assert!(!result.contains("This is a comment"));
+        assert!(!result.contains("block comment"));
+        assert!(result.contains("Visible text."));
+        assert!(result.contains("More text."));
+    }
+
+    #[test]
+    fn empty_document() {
+        assert_eq!(extract_prose(""), "");
+    }
+
+    #[test]
+    fn escape_sequences() {
+        let typ = r"Use \# for a literal hash and \* for an asterisk.";
+        let result = extract_prose(typ);
+        assert!(result.contains("#"));
+        assert!(result.contains("*"));
+    }
+
+    #[test]
+    fn multiple_paragraphs() {
+        let typ = "First paragraph with some content.\n\nSecond paragraph with more.";
+        let result = extract_prose(typ);
+        assert!(result.contains("First paragraph"));
+        assert!(result.contains("Second paragraph"));
+    }
+
+    #[test]
+    fn realistic_document() {
+        let typ = r#"#set document(title: "My Book")
+#set text(font: "New Computer Modern")
+
+= Chapter 1: Authentication <ch1>
+
+OAuth provides delegated authorization. OAuth 2.0 is the
+current standard for token-based access control.
+
+== Password Hashing
+
+Password hashing uses *bcrypt* or _argon2_ for secure
+storage. The `hash()` function takes a plaintext input.
+
+$H(p) = "hash"$
+
+See @ch1 for more details.
+
+// TODO: add more content
+"#;
+        let result = extract_prose(typ);
+        // Prose preserved
+        assert!(result.contains("OAuth provides delegated authorization."));
+        assert!(result.contains("Password hashing uses"));
+        assert!(result.contains("bcrypt"));
+        assert!(result.contains("argon2"));
+        // Headings excluded
+        assert!(!result.contains("Chapter 1"));
+        assert!(!result.contains("Password Hashing"));
+        // Code/math stripped
+        assert!(!result.contains("hash()"));
+        assert!(!result.contains("H(p)"));
+        // Function calls stripped
+        assert!(!result.contains("set document"));
+        assert!(!result.contains("set text"));
+        // Labels/refs stripped
+        assert!(!result.contains("<ch1>"));
+        assert!(!result.contains("@ch1"));
+        // Comments stripped
+        assert!(!result.contains("TODO"));
+    }
+}


### PR DESCRIPTION
Wire typst-syntax 0.14.2 into the extraction pipeline. New extract/typst.rs
walks the lossless AST to extract prose text, skipping headings, raw/code
blocks, math equations, labels, references, links, comments, and code-mode
function calls. Strong/emphasis text preserved. Same strategy as the
pulldown-cmark markdown extractor.
Pipeline dispatches by file extension — mixed .md + .typ corpora work
seamlessly via extract_prose_for(). collect_documents() now returns the
extension alongside path and content.
23 new tests (20 unit + 3 integration including mixed-corpus).
127 total tests passing.