### PR TITLE
fix(core): remediate audit findings for validation and main-file detection

### DIFF
--- a/.handoffs/2026-03-21-1139-validate-phantom-locations.md
+++ b/.handoffs/2026-03-21-1139-validate-phantom-locations.md
@@ -1,0 +1,31 @@
+# Handoff: Post-Curate Location Validation
+
+**Date:** 2026-03-21
+**Branch:** `fix/validate-phantom-locations`
+**State:** Green — 260/260 tests pass, clippy clean.
+
+## Where things stand
+
+The validate module is complete and integrated into the CLI. After `colophon curate` writes `colophon-terms.yaml`, it checks each term+location against source files and suggests missing aliases when the canonical term can't be found. A `commit.txt` is ready for squash-merge. The `chore/update-template` branch work (conflict resolution, Homebrew tap rename) was committed separately and merged earlier — this branch builds on top of it.
+
+## Decisions made
+
+- **Phantom locations are 96% a curate problem**, not extract — Claude renames terms during curation ("Slack" -> "Slack integration") but doesn't always add the original form as an alias. Only 6 of 132 phantoms were singular/plural mismatches.
+- **Shared `typst_prose` module** — extracted `collect_prose_ranges` and `find_term_offset_in_prose` from `render/typst.rs` into `crate::typst_prose` (pub(crate)) so both render and validate can use AST-aware prose search.
+- **Suggestion heuristic order**: suffixes first (drop from front: "Amazon Bedrock" -> "Bedrock"), then prefixes (drop from end), then singular/plural toggle. This order favors the dominant real-world pattern where generic prefixes get prepended during curation.
+- **Validation is advisory, not blocking** — suggestions print to stderr after the curate summary table. Skipped in `--json` and `--dry-run` modes.
+- **Fixed pre-existing test** — `extract_produces_yaml_output` was asserting on stdout but extract writes its table to stderr. Changed to `.stderr()` assertions.
+
+## What's next
+
+1. **Squash-merge this branch** — `commit.txt` is ready. 6 commits to squash.
+2. **Test incremental curate against real corpus** — still untested end-to-end with actual Claude invocation on the 67-file Typst corpus at `~/source/claude/build`. Run `colophon extract && colophon curate` then again with a small edit.
+3. **Consider tightening curate prompt** — tell Claude to always include the original extracted term as an alias when renaming. This reduces phantoms at the source rather than patching after.
+4. **Fix phantom locations in extract** (lower priority) — the 6 singular/plural mismatches could be caught during extract by verifying candidates against original source. The `typst_prose` module is now available for this.
+
+## Landmines
+
+- **`toggle_plural` is intentionally naive** — `strip_suffix('s')` turns "status" into "statu" and "access" into "acces". These are harmless (they won't match anything) but look wrong if you read the code without context.
+- **Suffix-before-prefix heuristic** can suggest common words for 2-word terms — e.g., "OAuth providers" would suggest "providers" instead of "OAuth". Works well for the dominant pattern (generic prefix + specific term) but poorly for the inverse.
+- **`validate_locations` reads source files** — it needs the actual source directory to be accessible. If called with a stale `source_dir` in the terms file, it silently counts everything as unresolved.
+- **`_candidates_yaml` unused param** in `run_incremental` (`curate/mod.rs`) — pre-existing, not from this branch. The `_` prefix suppresses the warning.

--- a/crates/colophon-core/src/curate/mod.rs
+++ b/crates/colophon-core/src/curate/mod.rs
@@ -348,7 +348,7 @@ fn post_process(
                             let is_main = ct
                                 .main_files
                                 .iter()
-                                .any(|mf| loc.file.contains(mf.as_str()));
+                                .any(|mf| std::path::Path::new(&loc.file).ends_with(mf.as_str()));
                             locations.push(TermLocation {
                                 file: loc.file.clone(),
                                 main: is_main,
@@ -561,6 +561,73 @@ mod tests {
 
         let api_loc = oauth.locations.iter().find(|l| l.file == "api.md").unwrap();
         assert!(!api_loc.main, "api.md should not be main for OAuth");
+    }
+
+    #[test]
+    fn post_process_main_files_rejects_substring_overlap() {
+        // Regression: "auth.md" in main_files must NOT match "old-auth.md"
+        let candidates = CandidatesFile {
+            version: 1,
+            generated: "2026-03-25T00:00:00Z".to_string(),
+            source_dir: "src/".to_string(),
+            document_count: 3,
+            candidates: vec![Candidate {
+                term: "OAuth".to_string(),
+                score: 0.95,
+                locations: vec![
+                    CandidateLocation {
+                        file: "auth.md".to_string(),
+                        context: "OAuth is used here".to_string(),
+                    },
+                    CandidateLocation {
+                        file: "old-auth.md".to_string(),
+                        context: "Legacy OAuth reference".to_string(),
+                    },
+                    CandidateLocation {
+                        file: "appendix/auth.md.bak".to_string(),
+                        context: "Backup mention".to_string(),
+                    },
+                ],
+            }],
+        };
+        let output = ClaudeOutput {
+            terms: vec![terms::ClaudeTerm {
+                term: "OAuth".to_string(),
+                definition: "Open authorization standard.".to_string(),
+                parent: None,
+                aliases: Vec::new(),
+                see_also: Vec::new(),
+                main_files: vec!["auth.md".to_string()],
+            }],
+            suggested: Vec::new(),
+        };
+
+        let terms = post_process(&output, &candidates, 200);
+        let oauth = terms.iter().find(|t| t.term == "OAuth").unwrap();
+
+        let auth = oauth
+            .locations
+            .iter()
+            .find(|l| l.file == "auth.md")
+            .unwrap();
+        assert!(auth.main, "auth.md should be main");
+
+        let old_auth = oauth
+            .locations
+            .iter()
+            .find(|l| l.file == "old-auth.md")
+            .unwrap();
+        assert!(
+            !old_auth.main,
+            "old-auth.md must NOT be main (substring overlap)"
+        );
+
+        let bak = oauth
+            .locations
+            .iter()
+            .find(|l| l.file == "appendix/auth.md.bak")
+            .unwrap();
+        assert!(!bak.main, "auth.md.bak must NOT be main");
     }
 
     #[test]

--- a/crates/colophon-core/src/render/mod.rs
+++ b/crates/colophon-core/src/render/mod.rs
@@ -106,7 +106,16 @@ pub(crate) fn build_parent_chain(term_name: &str, terms: &[CuratedTerm]) -> Vec<
 pub(crate) fn find_term_offset(text: &str, term: &str) -> Option<usize> {
     let lower_text = text.to_lowercase();
     let lower_term = term.to_lowercase();
-    lower_text.find(&lower_term).map(|pos| pos + term.len())
+    lower_text.find(&lower_term).and_then(|pos| {
+        let offset = pos + term.len();
+        // Guard: offset from lowered buffer may not be a char boundary in the
+        // original text when Unicode case folding changes byte lengths.
+        if offset <= text.len() && text.is_char_boundary(offset) {
+            Some(offset)
+        } else {
+            None
+        }
+    })
 }
 
 /// Render format selection.

--- a/crates/colophon-core/src/render/typst.rs
+++ b/crates/colophon-core/src/render/typst.rs
@@ -37,7 +37,7 @@ impl Renderer for TypstRenderer {
         // Insert markers at descending byte offsets.
         for ann in annotations {
             let marker = self.format_marker(&ann.term, &ann.parent_chain, ann.main);
-            if ann.byte_offset <= result.len() {
+            if ann.byte_offset <= result.len() && result.is_char_boundary(ann.byte_offset) {
                 result.insert_str(ann.byte_offset, &marker);
             }
         }

--- a/crates/colophon-core/src/typst_prose.rs
+++ b/crates/colophon-core/src/typst_prose.rs
@@ -112,19 +112,27 @@ pub fn find_term_offset_in_prose(
             .any(|&(rs, re)| abs_pos >= rs && abs_end <= re);
 
         if in_prose {
-            // Skip if next char is '.' followed by alpha — inserting a marker
-            // here would create a Typst field access on the marker's return value.
-            // e.g., "plugins.gradle.org" → "plugins#index[plugins].gradle.org" is broken.
-            let next_is_field_access = source.as_bytes().get(abs_end) == Some(&b'.')
-                && source
-                    .as_bytes()
-                    .get(abs_end + 1)
-                    .is_some_and(|b| b.is_ascii_alphabetic());
-            if !next_is_field_access {
-                return Some(abs_end);
+            // Guard: offset from lowered buffer may not be valid in the original
+            // source when Unicode case folding changes byte lengths.
+            if abs_end <= source.len() && source.is_char_boundary(abs_end) {
+                // Skip if next char is '.' followed by alpha — inserting a marker
+                // here would create a Typst field access on the marker's return value.
+                // e.g., "plugins.gradle.org" → "plugins#index[plugins].gradle.org" is broken.
+                let next_is_field_access = source.as_bytes().get(abs_end) == Some(&b'.')
+                    && source
+                        .as_bytes()
+                        .get(abs_end + 1)
+                        .is_some_and(|b| b.is_ascii_alphabetic());
+                if !next_is_field_access {
+                    return Some(abs_end);
+                }
             }
         }
+        // Advance start to next char boundary in the lowered buffer.
         start = abs_pos + 1;
+        while start < lower_source.len() && !lower_source.is_char_boundary(start) {
+            start += 1;
+        }
     }
     None
 }

--- a/crates/colophon-core/src/validate.rs
+++ b/crates/colophon-core/src/validate.rs
@@ -17,6 +17,17 @@ pub struct AliasSuggestion {
     pub suggested_alias: String,
 }
 
+/// An unresolved location where the heuristic could not suggest an alias.
+#[derive(Debug, Clone)]
+pub struct UnresolvedDetail {
+    /// Canonical term that can't be found.
+    pub term: String,
+    /// Source file where the term was expected.
+    pub file: String,
+    /// Whether the source file itself is missing.
+    pub file_missing: bool,
+}
+
 /// Summary of a validation pass.
 #[derive(Debug, Default)]
 pub struct ValidationReport {
@@ -26,6 +37,8 @@ pub struct ValidationReport {
     pub unresolved: usize,
     /// Suggested aliases for unresolved locations.
     pub suggestions: Vec<AliasSuggestion>,
+    /// Unresolved locations where no alias could be suggested.
+    pub unresolved_no_suggestion: Vec<UnresolvedDetail>,
 }
 
 /// File content cache entry.
@@ -68,8 +81,13 @@ pub fn validate_locations(
                 .or_insert_with(|| load_file(source_dir, &loc.file));
 
             let Some(entry) = entry else {
-                // File doesn't exist — unresolved, but no suggestion possible.
+                // File doesn't exist — unresolved, no suggestion possible.
                 report.unresolved += 1;
+                report.unresolved_no_suggestion.push(UnresolvedDetail {
+                    term: curated.term.clone(),
+                    file: loc.file.clone(),
+                    file_missing: true,
+                });
                 continue;
             };
 
@@ -99,6 +117,12 @@ pub fn validate_locations(
                     term: curated.term.clone(),
                     file: loc.file.clone(),
                     suggested_alias: suggested,
+                });
+            } else {
+                report.unresolved_no_suggestion.push(UnresolvedDetail {
+                    term: curated.term.clone(),
+                    file: loc.file.clone(),
+                    file_missing: false,
                 });
             }
         }
@@ -268,6 +292,9 @@ mod tests {
         let report = validate_locations(&tf, &tf.source_dir, &[]);
         assert_eq!(report.unresolved, 1);
         assert!(report.suggestions.is_empty());
+        assert_eq!(report.unresolved_no_suggestion.len(), 1);
+        assert_eq!(report.unresolved_no_suggestion[0].term, "Zyxelfrob");
+        assert!(!report.unresolved_no_suggestion[0].file_missing);
     }
 
     #[test]
@@ -333,6 +360,8 @@ mod tests {
         let report = validate_locations(&tf, &tf.source_dir, &[]);
         assert_eq!(report.unresolved, 1);
         assert!(report.suggestions.is_empty());
+        assert_eq!(report.unresolved_no_suggestion.len(), 1);
+        assert!(report.unresolved_no_suggestion[0].file_missing);
     }
 
     // ── Task 3 tests ────────────────────────────────────────────────

--- a/crates/colophon/src/commands/curate.rs
+++ b/crates/colophon/src/commands/curate.rs
@@ -57,15 +57,27 @@ fn display_validation(
 ) {
     let report =
         colophon_core::validate::validate_locations(terms, &terms.source_dir, source_extensions);
-    if !report.suggestions.is_empty() {
+    if report.unresolved > 0 {
         eprintln!();
         eprintln!(
             "Validation: {} resolved, {} unresolved",
             report.resolved, report.unresolved
         );
-        eprintln!("Suggested aliases for unresolved locations:");
-        for s in &report.suggestions {
-            eprintln!("  {} -> add alias \"{}\"", s.term, s.suggested_alias);
+        if !report.suggestions.is_empty() {
+            eprintln!("Suggested aliases for unresolved locations:");
+            for s in &report.suggestions {
+                eprintln!("  {} -> add alias \"{}\"", s.term, s.suggested_alias);
+            }
+        }
+        for detail in &report.unresolved_no_suggestion {
+            if detail.file_missing {
+                eprintln!("  {} in {} (file not found)", detail.term, detail.file);
+            } else {
+                eprintln!(
+                    "  {} in {} (not found, no suggestion)",
+                    detail.term, detail.file
+                );
+            }
         }
     }
 }

--- a/record/audits/2026-03-21-current-repo-review/actions-taken.md
+++ b/record/audits/2026-03-21-current-repo-review/actions-taken.md
@@ -1,0 +1,64 @@
+---
+audit: 2026-03-21-current-repo-review
+last_updated: 2026-03-25
+status:
+  fixed: 2
+  mitigated: 1
+  accepted: 0
+  disputed: 0
+  deferred: 0
+  open: 0
+---
+
+# Actions Taken: Current Repo Review
+
+Summary of remediation status for the [2026-03-21 current repo review](index.md).
+
+---
+
+## 2026-03-25 — Validation always reports unresolved locations
+
+**Disposition:** fixed
+**Addresses:** [curate-validation-suppresses-unresolved-without-suggestion](index.md#curate-validation-suppresses-unresolved-without-suggestion)
+**Commit:** pending (branch `fix/audit-remediation`)
+**Author:** @claylo
+
+`display_validation()` now triggers on `report.unresolved > 0` instead of `!report.suggestions.is_empty()`. Added `UnresolvedDetail` struct and `unresolved_no_suggestion` vec to `ValidationReport` so the CLI can report missing files and no-match locations even when the heuristic has nothing to suggest.
+
+```rust crates/colophon/src/commands/curate.rs:60
+if report.unresolved > 0 {
+    // Always show summary + details, not just when suggestions exist
+}
+```
+
+---
+
+## 2026-03-25 — Main-file detection uses path component matching
+
+**Disposition:** fixed
+**Addresses:** [main-file-detection-uses-substring-match](index.md#main-file-detection-uses-substring-match)
+**Commit:** pending (branch `fix/audit-remediation`)
+**Author:** @claylo
+
+Switched from `loc.file.contains(mf.as_str())` to `Path::new(&loc.file).ends_with(mf.as_str())`. `Path::ends_with` compares path components, so `old-auth.md` no longer matches `auth.md` while `chapters/auth.md` still does. Regression test added with overlapping filenames (`auth.md`, `old-auth.md`, `appendix/auth.md.bak`).
+
+```rust crates/colophon-core/src/curate/mod.rs:351
+.any(|mf| std::path::Path::new(&loc.file).ends_with(mf.as_str()))
+```
+
+---
+
+## 2026-03-25 — Char-boundary guards for Unicode casefold offset drift
+
+**Disposition:** mitigated
+**Addresses:** [unicode-casefold-offsets-drift-from-source](index.md#unicode-casefold-offsets-drift-from-source)
+**Commit:** pending (branch `fix/audit-remediation`)
+**Author:** @claylo
+
+Added `is_char_boundary()` checks at all three sites where lowercased-buffer offsets are used against original source text:
+
+- `find_term_offset` returns `None` when offset isn't a valid char boundary in the original
+- `find_term_offset_in_prose` skips matches with invalid offsets and advances past multibyte chars instead of bare `+1`
+- `TypstRenderer::annotate` checks char boundary before `insert_str`
+
+This prevents panics but doesn't fix the root cause — terms near expanding Unicode case folds will silently become "not found" instead of being placed correctly. The correct fix is to scan the original buffer while comparing normalized slices, preserving true source spans. That's a medium-effort change for a future pass; the current corpus is English ASCII and unaffected.

--- a/record/audits/2026-03-21-current-repo-review/assets/terrain-map.svg
+++ b/record/audits/2026-03-21-current-repo-review/assets/terrain-map.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="220" viewBox="0 0 720 220">
+  <rect x="0" y="0" width="720" height="220" fill="#ffffff"/>
+  <text x="24" y="28" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 16px; fill: #1a1a1a;">Current repo review: curate / validate / render</text>
+  <line x1="120" y1="115" x2="280" y2="115" stroke="#6b7280" stroke-width="2"/>
+  <line x1="440" y1="115" x2="600" y2="115" stroke="#6b7280" stroke-width="2"/>
+  <line x1="280" y1="115" x2="440" y2="115" stroke="#1a1a1a" stroke-width="4"/>
+  <rect x="24" y="75" width="96" height="80" rx="8" fill="#d1d5db" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="72" y="110" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 14px; fill: #1a1a1a;">CLI</text>
+  <text x="72" y="129" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">commands/curate.rs</text>
+  <rect x="280" y="55" width="160" height="120" rx="8" fill="#d1d5db" stroke="#1a1a1a" stroke-width="3"/>
+  <text x="360" y="92" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 15px; fill: #1a1a1a;">Core pipeline</text>
+  <text x="360" y="113" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">curate/mod.rs</text>
+  <text x="360" y="131" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">validate.rs</text>
+  <text x="360" y="149" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">typst_prose.rs</text>
+  <rect x="600" y="75" width="96" height="80" rx="8" fill="#d1d5db" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="648" y="110" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 14px; fill: #1a1a1a;">Renderer</text>
+  <text x="648" y="129" text-anchor="middle" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">render/mod.rs</text>
+  <text x="24" y="194" style="font-family: -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; font-size: 11px; fill: #6b7280;">Heavier stroke marks the highest finding density in the curate/validate junction.</text>
+</svg>

--- a/record/audits/2026-03-21-current-repo-review/findings.yaml
+++ b/record/audits/2026-03-21-current-repo-review/findings.yaml
@@ -1,0 +1,89 @@
+audit_date: 2026-03-21
+scope: current-repo-review
+commit: 8a027bfb55da46d8cc0ee150edc01497b511c63b
+narratives:
+  - slug: location-truthfulness
+    title: The Location Truthfulness Surface
+    thesis: Recent validation work improves visibility, but two code paths still let the index claim confidence it has not actually earned.
+    verdict: The pipeline can silently preserve broken locations and can over-mark non-main files as substantive.
+    findings:
+      - slug: curate-validation-suppresses-unresolved-without-suggestion
+        concern: significant
+        locations:
+          - path: crates/colophon/src/commands/curate.rs
+            line_start: 58
+            line_end: 66
+        evidence: |
+          let report =
+              colophon_core::validate::validate_locations(terms, &terms.source_dir, source_extensions);
+          if !report.suggestions.is_empty() {
+              eprintln!(
+                  "Validation: {} resolved, {} unresolved",
+                  report.resolved, report.unresolved
+              );
+          }
+        mechanism: Curate only prints validation output when at least one alias suggestion exists. Missing files and plain unresolved locations increment `report.unresolved`, but they produce no operator-visible warning if the heuristic cannot suggest an alias. That means the new validation pass can fail and still look clean at the CLI, which defeats the purpose of catching bad locations before render.
+        remediation: Print a validation summary whenever `report.unresolved > 0`, and include unresolved file paths even when no alias can be suggested. A failing or warning exit mode would be better for CI.
+        temporal_context:
+          introduced_in: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+          introduced_date: 2026-03-21T00:34:34-04:00
+          last_touched_in: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+        chain_references:
+          enables:
+            - main-file-detection-uses-substring-match
+      - slug: main-file-detection-uses-substring-match
+        concern: moderate
+        locations:
+          - path: crates/colophon-core/src/curate/mod.rs
+            line_start: 348
+            line_end: 351
+        evidence: |
+          let is_main = ct
+              .main_files
+              .iter()
+              .any(|mf| loc.file.contains(mf.as_str()));
+        mechanism: `main_files` is treated as a substring, not a path identity check. A term marked main for `auth.md` will also mark `chapters/auth.md.bak`, `old-auth.md`, or any other path containing that fragment as substantive. The result is quietly incorrect bold page numbers in the rendered index, which is exactly the metadata the curation step is supposed to preserve accurately.
+        remediation: Normalize both sides to repository-relative paths and compare for exact equality. Add a regression test with overlapping names such as `auth.md` and `old-auth.md`.
+        temporal_context:
+          introduced_in: c295e397b9a3466e1c8c73fe52c2508c5b149959
+          introduced_date: 2026-03-19T20:33:30-04:00
+          last_touched_in: 8a027bfb55da46d8cc0ee150edc01497b511c63b
+        chain_references:
+          enabled_by:
+            - curate-validation-suppresses-unresolved-without-suggestion
+  - slug: text-boundary-accounting
+    title: The Text Boundary Surface
+    thesis: Case-insensitive matching is implemented by lowercasing whole buffers and then reusing those offsets against the original source, which is only safe for ASCII-stable case folds.
+    verdict: The matcher is robust for English ASCII inputs, but it is not correct for general Unicode text.
+    findings:
+      - slug: unicode-casefold-offsets-drift-from-source
+        concern: moderate
+        locations:
+          - path: crates/colophon-core/src/render/mod.rs
+            line_start: 106
+            line_end: 109
+          - path: crates/colophon-core/src/typst_prose.rs
+            line_start: 101
+            line_end: 118
+        evidence: |
+          let lower_text = text.to_lowercase();
+          let lower_term = term.to_lowercase();
+          lower_text.find(&lower_term).map(|pos| pos + term.len())
+
+          let lower_source = source.to_lowercase();
+          let lower_term = term.to_lowercase();
+          let abs_pos = start + pos;
+          let abs_end = abs_pos + lower_term.len();
+        mechanism: Lowercasing can change byte lengths and byte positions for Unicode text (`İ`, Greek sigma variants, Lithuanian dotted forms, and others). Once offsets are computed against the lowercased buffer, they are no longer guaranteed to be valid offsets in the original source. That can produce wrong insertion points, false negatives, or invalid prose-boundary checks in exactly the multilingual manuscripts this tool is likely to see.
+        remediation: Use Unicode-aware case-insensitive matching that preserves original spans, or scan the original string by grapheme/char boundaries while comparing normalized slices. Add tests with at least one expanding case fold.
+        temporal_context:
+          introduced_in: 8855d1a30c42e7014e187f2579d9ca31a489c4ec
+          introduced_date: 2026-03-20T11:56:13-04:00
+          last_touched_in: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+        chain_references: {}
+summary:
+  counts:
+    significant: 1
+    moderate: 2
+    advisory: 0
+    note: 0

--- a/record/audits/2026-03-21-current-repo-review/index.md
+++ b/record/audits/2026-03-21-current-repo-review/index.md
@@ -1,0 +1,106 @@
+---
+audit_date: 2026-03-21
+scope: current-repo-review
+commit: 8a027bfb55da46d8cc0ee150edc01497b511c63b
+agent: Codex
+summary:
+  significant: 1
+  moderate: 2
+  advisory: 0
+  note: 0
+---
+
+# Current Repo Review
+
+![Terrain map](assets/terrain-map.svg)
+
+This review focused on the current repository state, with attention on the recently changed `curate -> validate -> render` path. The workspace test suite was green under `cargo nextest run --workspace`, so the findings below are gaps in current assertions rather than failures already caught by the existing suite.
+
+## The Location Truthfulness Surface
+
+The recent validation pass is useful, but the CLI still has a blind spot: it only tells the operator about validation when there is a suggested alias to print. That means a broken location with no heuristic recovery path can pass through curate without any visible warning.
+
+### `curate-validation-suppresses-unresolved-without-suggestion`
+
+> If a file is missing or the term simply is not there, I do not need to fool the validator. I just need it to fail in a way the CLI decides not to mention.
+
+Evidence:
+
+```rust
+crates/colophon/src/commands/curate.rs
+let report =
+    colophon_core::validate::validate_locations(terms, &terms.source_dir, source_extensions);
+if !report.suggestions.is_empty() {
+    eprintln!(
+        "Validation: {} resolved, {} unresolved",
+        report.resolved, report.unresolved
+    );
+}
+```
+
+`validate_locations()` increments `report.unresolved` for missing files and plain misses, but `display_validation()` only emits output when the alias heuristic found something to suggest. That suppresses the exact cases the validation pass was meant to surface: locations that are simply wrong. In practice this turns validation into a partial hinting feature instead of a trustworthy post-curate gate.
+
+Remediation should start with always printing a validation summary when unresolved locations exist, followed by file-level details. If this command is expected to run in CI, unresolved locations should also be eligible for a non-zero exit status.
+
+Temporal context: this reporting gate arrived in commit `60bf2994b756b17fa7dbc3d0b970c1e283c4e404` on 2026-03-21 and has not been meaningfully revised since.
+
+### `main-file-detection-uses-substring-match`
+
+The same surface also overstates certainty about which files are substantive discussions. `main_files` is treated as a substring rather than a specific path identity.
+
+```rust
+crates/colophon-core/src/curate/mod.rs
+let is_main = ct
+    .main_files
+    .iter()
+    .any(|mf| loc.file.contains(mf.as_str()));
+```
+
+This is quiet data corruption, not a crash. If Claude marks `auth.md` as substantive, any candidate location whose path merely contains that fragment can also become `main: true`. A corpus with `old-auth.md`, `appendix/auth.md.bak`, or similar overlaps will get bold page numbers in the final index where none were intended.
+
+Exact relative-path comparison is the safe default here. A regression test with overlapping file names would lock it down.
+
+Temporal context: the mapping logic was introduced with the initial curate post-processing and remains live in `HEAD`.
+
+---
+
+## The Text Boundary Surface
+
+The render and Typst prose matchers both implement case-insensitive search by lowercasing whole buffers and then reusing those offsets against the original source. That works for ASCII. It is not a correct model for Unicode text.
+
+### `unicode-casefold-offsets-drift-from-source`
+
+> I do not care whether the search is “case-insensitive” in theory. I care whether the byte offset still points at the same place in the original manuscript after the fold.
+
+Evidence:
+
+```rust
+crates/colophon-core/src/render/mod.rs
+let lower_text = text.to_lowercase();
+let lower_term = term.to_lowercase();
+lower_text.find(&lower_term).map(|pos| pos + term.len())
+```
+
+```rust
+crates/colophon-core/src/typst_prose.rs
+let lower_source = source.to_lowercase();
+let lower_term = term.to_lowercase();
+let abs_pos = start + pos;
+let abs_end = abs_pos + lower_term.len();
+```
+
+Unicode case folding is not length-preserving. Some characters expand or normalize differently when folded, which means offsets discovered in the lowercased buffer are not guaranteed to map back to the same byte positions in the original source. Once that happens, render can insert markers at the wrong place and the Typst prose validator can misclassify whether a hit is inside a safe prose span.
+
+This is a robustness bug rather than an exploit path, but it matters in exactly the multilingual publishing workflows a glossary/index tool should handle well. The fix is to compare against the original buffer while preserving original spans, not to search a transformed copy and reuse its byte indices.
+
+Temporal context: the render matcher shipped in `8855d1a30c42e7014e187f2579d9ca31a489c4ec`; the same pattern was propagated into the shared Typst prose matcher in `60bf2994b756b17fa7dbc3d0b970c1e283c4e404`.
+
+---
+
+## Remediation Ledger
+
+| Narrative | Slug | Concern | Location | Effort | Chain dependencies |
+| --- | --- | --- | --- | --- | --- |
+| The Location Truthfulness Surface | [curate-validation-suppresses-unresolved-without-suggestion](#curate-validation-suppresses-unresolved-without-suggestion) | significant | `crates/colophon/src/commands/curate.rs:58` | small | enables `main-file-detection-uses-substring-match` |
+| The Location Truthfulness Surface | [main-file-detection-uses-substring-match](#main-file-detection-uses-substring-match) | moderate | `crates/colophon-core/src/curate/mod.rs:348` | trivial | enabled by `curate-validation-suppresses-unresolved-without-suggestion` |
+| The Text Boundary Surface | [unicode-casefold-offsets-drift-from-source](#unicode-casefold-offsets-drift-from-source) | moderate | `crates/colophon-core/src/render/mod.rs:106`, `crates/colophon-core/src/typst_prose.rs:101` | medium | none |

--- a/record/audits/2026-03-21-current-repo-review/recon.yaml
+++ b/record/audits/2026-03-21-current-repo-review/recon.yaml
@@ -1,0 +1,98 @@
+audit_date: 2026-03-21
+scope: current-repo-review
+commit: 8a027bfb55da46d8cc0ee150edc01497b511c63b
+entry_points:
+  - path: crates/colophon/src/main.rs
+    kind: cli-main
+  - path: crates/colophon/src/commands/curate.rs
+    kind: cli-command
+  - path: crates/colophon/src/commands/render.rs
+    kind: cli-command
+  - path: crates/colophon-core/src/curate/mod.rs
+    kind: library-pipeline
+  - path: crates/colophon-core/src/render/mod.rs
+    kind: library-pipeline
+  - path: crates/colophon-core/src/validate.rs
+    kind: library-validation
+files:
+  - path: crates/colophon-core/src/curate/mod.rs
+    lines: 640
+    last_commit: 8a027bfb55da46d8cc0ee150edc01497b511c63b
+    last_commit_date: 2026-03-21T00:42:04-04:00
+  - path: crates/colophon-core/src/render/mod.rs
+    lines: 642
+    last_commit: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+    last_commit_date: 2026-03-21T00:34:34-04:00
+  - path: crates/colophon-core/src/typst_prose.rs
+    lines: 240
+    last_commit: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+    last_commit_date: 2026-03-21T00:34:34-04:00
+  - path: crates/colophon-core/src/validate.rs
+    lines: 441
+    last_commit: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+    last_commit_date: 2026-03-21T00:34:34-04:00
+  - path: crates/colophon/src/commands/curate.rs
+    lines: 506
+    last_commit: 60bf2994b756b17fa7dbc3d0b970c1e283c4e404
+    last_commit_date: 2026-03-21T00:34:34-04:00
+  - path: crates/colophon/src/main.rs
+    lines: 82
+    last_commit: 40ea5ff635c79fbafa9bb21d6cfdc1852d7ce7b4
+    last_commit_date: 2026-03-20T18:51:24-04:00
+dependency_graph:
+  - from: crates/colophon/src/main.rs
+    to:
+      - crates/colophon/src/commands/curate.rs
+      - crates/colophon/src/commands/render.rs
+      - crates/colophon-core/src/config.rs
+      - crates/colophon-core/src/observability.rs
+  - from: crates/colophon/src/commands/curate.rs
+    to:
+      - crates/colophon-core/src/curate/mod.rs
+      - crates/colophon-core/src/validate.rs
+  - from: crates/colophon/src/commands/render.rs
+    to:
+      - crates/colophon-core/src/render/mod.rs
+  - from: crates/colophon-core/src/validate.rs
+    to:
+      - crates/colophon-core/src/typst_prose.rs
+  - from: crates/colophon-core/src/render/mod.rs
+    to:
+      - crates/colophon-core/src/render/typst.rs
+      - crates/colophon-core/src/curate/terms.rs
+  - from: crates/colophon-core/src/curate/mod.rs
+    to:
+      - crates/colophon-core/src/curate/claude.rs
+      - crates/colophon-core/src/curate/incremental.rs
+      - crates/colophon-core/src/curate/terms.rs
+dependency_manifest:
+  crate: colophon-core
+  notable_external_deps:
+    - camino 1.2
+    - indicatif 0.18.4
+    - pulldown-cmark 0.13
+    - serde_yaml 0.9
+    - typst-syntax 0.14.0
+    - walkdir 2
+  cli_deps:
+    - clap 4.6
+    - tabled 0.20.0
+    - owo-colors 4.3
+git_churn:
+  hotspot_paths:
+    - crates/colophon-core/src/curate/mod.rs
+    - crates/colophon-core/src/render/mod.rs
+    - crates/colophon/src/commands/curate.rs
+  recent_authors:
+    - Clay Loveless
+trust_boundaries:
+  - boundary: filesystem
+    notes: user-provided source trees and generated output files
+  - boundary: external-llm-cli
+    notes: Claude CLI output is post-processed into curated terms
+  - boundary: typst-source-parsing
+    notes: byte offsets derived from AST-safe prose ranges are later used to edit source text
+validation:
+  checks_run:
+    - cargo nextest run --workspace
+  result: pass


### PR DESCRIPTION
Address findings #1 and #2 from the 2026-03-21 repo audit, plus
defensive guards against Unicode casefold panics (finding #3).
Validation truthfulness (significant):
- Always display validation summary when unresolved > 0, not only
  when alias suggestions exist
- Track unresolved-without-suggestion locations (missing files and
  plain misses) in new UnresolvedDetail struct
- CLI now reports file-not-found and no-suggestion cases to stderr
Main-file substring overlap (moderate):
- Switch from string contains() to Path::ends_with() for main_files
  matching — prevents "auth.md" from falsely matching "old-auth.md"
  or "auth.md.bak" while still matching "chapters/auth.md"
- Regression test with overlapping filenames
Unicode casefold panic guards (moderate):
- Add char-boundary checks before insert_str in Typst annotator
- Validate offsets against original source in find_term_offset and
  find_term_offset_in_prose before returning
- Advance search cursor past multibyte chars instead of bare +1
- Terms with drifted offsets gracefully become "not found" instead
  of panicking
261/261 tests pass, clippy clean.